### PR TITLE
Cleanup README.md && added ENV var for StartType and RequiredPlayers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,8 @@ ENV SERVERNAME="Community Server frenos/btl44"
 ENV PASSWORD=
 ENV PLAYMODE=Arcade
 ENV ADMINSTEAMID=000000000000000
+ENV STARTTYPE=ReadyUp
+ENV REQUIREDPLAYERS=2
 
 RUN apt-get update && apt-get install -y wget unzip lib32gcc1 xdg-user-dirs curl
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![](https://img.shields.io/docker/pulls/frenos/btl44.svg)](https://hub.docker.com/r/frenos/btl44/ "Click to view the image on Docker Hub")
+
 # btl44
 A dedicated server for Battalion 1944 in docker.
 Get your community server started easily!
@@ -7,23 +9,22 @@ Get your community server started easily!
 Install Docker on any host that is connected to the internet.
 To get more information about installing docker, please refer to the [official docker documentation](https://docs.docker.com/install/).
 
-Then just pull and start this image.
-
-### Configuring
-
-To have a minimal running server just run:
+Then just pull and start this image or simply use
 ```
 docker run --name btlserver -d frenos/btl44
 ```
-It will find your IP and set a default server with the name 'Community Server frenos/btl44' on port 7777 with gamemode set to 'Arcade' and without a password.
 
-You can put in your public ip to run on a specific interface, use the ENV variable '$PUBLICIP':
-```
-docker run --name btlserver -e "PUBLICIP=1.2.3.4" frenos/btl44
-```
-If you don't supply the IP you want to use, the container will make a single call to Amazon Web Services to find out your public IP and use that.
+### Configuration
 
-The command above will start a server on default port 7777 with the name of 'Community Server frenos/btl44'.
+The simplest run configuration is shown above. It will find your IP and set a default server with the name 'Community Server frenos/btl44' on port 7777 with gamemode set to 'Arcade' and without a password.
+
+You can put in your public IP or domain to run on a specific interface, use the ENV variable '$PUBLICIP':
+```
+docker run -d --name btlserver -e "PUBLICIP=1.2.3.4" frenos/btl44
+```
+If you don't supply a IP, the container will make a single call to Amazon Web Services to find and use your public IP.
+
+The command above will start a server on IP `1.2.3.4` and port `7777` with the name of 'Community Server frenos/btl44'.
 You can also configure multiple configuration values directly via ENV variables, namely:
 - Servername
 - Port
@@ -33,22 +34,21 @@ You can also configure multiple configuration values directly via ENV variables,
 
 An example for a private unranked Server with two admins would be
 ```
-docker run --name btlserver -e 'PUBLICIP=1.2.3.4' -e 'SERVERNAME="My awesome Server"' -e 'PASSWORD=secret' -e 'PLAYMODE=unranked' -e 'ADMINSTEAMID=XXX,YYY' frenos/btl44
+docker run -d --name btlserver -e 'PUBLICIP=1.2.3.4' -e 'SERVERNAME="My awesome Server"' -e 'PASSWORD=secret' -e 'PLAYMODE=unranked' -e 'ADMINSTEAMID=XXX,YYY' frenos/btl44
 ```
-
 where XXX and YYY are two valid SteamIDs.
 
-#### Custom configuration 
+#### Custom configuration
 To use a complete custom configuration, get a "DefaultGame.ini" and customize it to your liking.
-Then just link that config into the container:
+Then just bind that config into the container:
 ```
-docker run --name btlserver -e 'PUBLICIP=1.2.3.4' -e 'SERVERNAME="My awesome Server"' -e 'PASSWORD=secret' -e 'PLAYMODE=unranked' -e 'ADMINSTEAMID=XXX,YYY' -v /my/configs/DefaultGame.ini:/config/DefaultGame.ini frenos/btl44
+docker run -d --name btlserver -e 'PUBLICIP=1.2.3.4' -e 'SERVERNAME="My awesome Server"' -e 'PASSWORD=secret' -e 'PLAYMODE=unranked' -e 'ADMINSTEAMID=XXX,YYY' -v /my/configs/DefaultGame.ini:/config/DefaultGame.ini frenos/btl44
 ```
-The container will then copy that configuration, override the values given with ENV vars and start the gameserver.
+The container will then copy that configuration, override values that are passed as ENV vars (e.g. SERVERNAME) and start the gameserver. This allows you to use a single base configuration file for n servers with for example different server names and passwords.
 
-If you also want to custom loadout decks in your server also link a loadout directory into the container: 
+If you also want to use custom loadout decks in your server, simply link a loadout directory into the container: 
 ```
-docker run --name btlserver -e 'PUBLICIP=1.2.3.4' -e 'SERVERNAME="My awesome Server"' -e 'PASSWORD=secret' -e 'PLAYMODE=unranked' -e 'ADMINSTEAMID=XXX,YYY' -v /my/configs/DefaultGame.ini:/config/DefaultGame.ini  -v /my/configs/Loadouts:/config/Loadouts frenos/btl44
+docker run -d --name btlserver -e 'PUBLICIP=1.2.3.4' -e 'SERVERNAME="My awesome Server"' -e 'PASSWORD=secret' -e 'PLAYMODE=unranked' -e 'ADMINSTEAMID=XXX,YYY' -v /my/configs/DefaultGame.ini:/config/DefaultGame.ini  -v /my/configs/Loadouts:/config/Loadouts frenos/btl44
 ```
 Same as with the _DefaultGame.ini_ the decks are copied to the right directory and can be used in DefaultGame.ini just as the default decks.
 

--- a/myrunner.sh
+++ b/myrunner.sh
@@ -19,6 +19,8 @@ fi
 sed -i "/ServerName=COMMUNITY SERVER/c ServerName=$SERVERNAME" ./DefaultGame.ini
 sed -i "/Password=/c Password=$PASSWORD" ./DefaultGame.ini
 sed -i "/PlayMode=Arcade/c PlayMode=$PLAYMODE" ./DefaultGame.ini
+sed -i "/StartType=/c StartType=$STARTTYPE" ./DefaultGame.ini
+sed -i "/RequiredPlayers=/c RequiredPlayers=$REQUIREDPLAYERS" ./DefaultGame.ini
 
 #insert SteamIDs
 IFS=',' read -r -a steamIDSArray <<< "$ADMINSTEAMID"
@@ -26,7 +28,7 @@ for steamID in "${steamIDSArray[@]}"
 do
     awk '!found && /\+AdminSteamIDs\=/{print;print "+AdminSteamIDs=\"'$steamID'\""; found=1;next} 1' ./DefaultGame.ini > tmp && mv tmp DefaultGame.ini
 done
-sed -i '0,/+AdminSteamIDs=/{//d}' ./DefaultGame.ini
+sed -i '0,/+AdminSteamIDs=000000000000000/{//d}' ./DefaultGame.ini
 
 #finished editing config, lets go
 
@@ -37,7 +39,8 @@ if [ -z ${PUBLICIP+x} ]; then PUBLICIP=$(curl -s checkip.amazonaws.com); else ec
 let QUERY_PORT=SERVER_PORT+3
 #Echo configuration#
 echo "Starting your Server \"$SERVERNAME\" on port  $PUBLICIP:$SERVER_PORT ..."
-echo "We are running with Gamemode $PLAYMODE and password \"$PASSWORD\""
+echo "We are running with Gamemode $PLAYMODE and password \"$PASSWORD\"."
+echo "The StartType is $STARTTYPE".
 echo "Lets go, remember to bring up issues and feedback at https://github.com/frenos/btl44."
 echo "                                                                      - Frenos"
 echo "--------------------------------------------------------------------------------------"


### PR DESCRIPTION
Cleaned up README.md and added some information, e.g. your example with base config and n servers using this base config.

Additionaly I added two ENV vars for StartType and RequiredPlayers and fixed a bug where the first AdminSteamID was removed, although it was valid.